### PR TITLE
Fix DHT manager and multi-network lookup

### DIFF
--- a/bitbootpy/__init__.py
+++ b/bitbootpy/__init__.py
@@ -1,1 +1,9 @@
-from bitbootpy.bitbootpy import *
+"""Top level package for BitBootPY.
+
+This module re-exports the public classes from the core implementation so that
+``from bitbootpy import BitBoot`` works as expected.
+"""
+
+from .core.bitbootpy import *  # noqa: F401,F403
+
+__all__ = ["BitBoot", "BitBootConfig"]

--- a/bitbootpy/core/dht_manager.py
+++ b/bitbootpy/core/dht_manager.py
@@ -1,51 +1,60 @@
 from __future__ import annotations
-from typing import List, Tuple, Set
+from typing import List, Optional
+
 from kademlia.network import Server
 from kademlia.routing import KBucket
 import asyncio
 
-
-KNOWN_HOSTS: Dict[str, List[Set[str, int]]]  = {
-        "bit_torrent": [
-            ("dht.transmissionbt.com", 6881),
-            ("dht.u-phoria.org", 6881),
-            ("dht.bt.am", 2710),
-            ("dht.ipred.org", 6969),
-            ("dht.pirateparty.gr", 80),
-            ("dht.zoink.nl", 80),
-            ("dht.openbittorrent.com", 80),
-            ("dht.istole.it", 6969),
-            ("dht.ccc.de", 80),
-            ("dht.leechers-paradise.org", 6969)
-        ],
-        "btc": [(),(),],
-        "sol": [(),()],
-        "eth": [(),()],
-        "ipfs": [(),()],
-        "arweave": [(),()]
-}
+from .known_hosts import KNOWN_HOSTS, KnownHost
 
 
 class DHTManager:
-    def __init__(self, bootstrap_nodes: List[Tuple[str, int]] = BT_DHT_DOMAINS):
+    """Manage interaction with a DHT backend.
+
+    Only the Kademlia backend is implemented at the moment but the class is
+    structured so that alternative backends can be introduced later.  The
+    manager bootstraps itself using known nodes for the selected network unless
+    explicit bootstrap nodes are supplied.
+    """
+
+    def __init__(
+        self,
+        bootstrap_nodes: Optional[List[KnownHost]] = None,
+        network: str = "bit_torrent",
+        backend: str = "kademlia",
+    ):
+        if backend != "kademlia":
+            # Future backends can be selected here
+            raise ValueError(f"Unsupported DHT backend: {backend}")
+
         self._server = Server()
-        self._bootstrap_nodes = bootstrap_nodes
+        self._network = network
+        self._bootstrap_nodes: List[KnownHost] = bootstrap_nodes or KNOWN_HOSTS.get(
+            network, []
+        )
+        self._backend = backend
 
     @classmethod
-    async def create(cls, bootstrap_nodes: List[Tuple[str, int]] = None):
-        print("DHTManager.create()")
-        instance = cls(bootstrap_nodes)
+    async def create(
+        cls,
+        bootstrap_nodes: Optional[List[KnownHost]] = None,
+        network: str = "bit_torrent",
+        backend: str = "kademlia",
+    ) -> "DHTManager":
+        """Asynchronously create and bootstrap a :class:`DHTManager`."""
+
+        instance = cls(bootstrap_nodes, network=network, backend=backend)
         await instance._bootstrap_dht()
         return instance
 
-    async def _bootstrap_dht(self, port: int = 5678):
-        print("DHTManager._bootstrap_dht()")
+    async def _bootstrap_dht(self, port: int = 5678) -> None:
+        """Start the local DHT node and bootstrap with known peers."""
+
         await self._server.listen(port)
 
         # Connect to known nodes
         for node in self._bootstrap_nodes:
-            print("DHTManager._bootstrap_dht(): node = ", node)
-            await self._server.bootstrap([node])
+            await self._server.bootstrap([(node.host, node.port)])
 
     def get_routing_table(self) -> List[KBucket]:
         return self._server.protocol.router.buckets

--- a/bitbootpy/core/known_hosts.py
+++ b/bitbootpy/core/known_hosts.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class KnownHost:
+    """Representation of a known bootstrap host."""
+    host: str
+    port: int
+
+
+# Known bootstrap hosts for various networks. Only the BitTorrent network has
+# real seed nodes at the moment but the structure allows additional networks or
+# backends to be added in the future.
+KNOWN_HOSTS: Dict[str, List[KnownHost]] = {
+    "bit_torrent": [
+        KnownHost("dht.transmissionbt.com", 6881),
+        KnownHost("dht.u-phoria.org", 6881),
+        KnownHost("dht.bt.am", 2710),
+        KnownHost("dht.ipred.org", 6969),
+        KnownHost("dht.pirateparty.gr", 80),
+        KnownHost("dht.zoink.nl", 80),
+        KnownHost("dht.openbittorrent.com", 80),
+        KnownHost("dht.istole.it", 6969),
+        KnownHost("dht.ccc.de", 80),
+        KnownHost("dht.leechers-paradise.org", 6969),
+    ],
+    # Placeholder entries for additional networks/backends.
+    "btc": [],
+    "sol": [],
+    "eth": [],
+    "ipfs": [],
+    "arweave": [],
+}

--- a/bitbootpy/examples/multi_peer.py
+++ b/bitbootpy/examples/multi_peer.py
@@ -2,6 +2,7 @@ import sys
 import os
 import asyncio
 from bitbootpy.core.bitbootpy import BitBoot, BitBootConfig, DHTManager
+from bitbootpy.core.known_hosts import KnownHost
 
 project_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, project_dir)
@@ -32,7 +33,7 @@ async def main():
 
     listening_host, listening_port = creator._dht_manager.get_server().transport.get_extra_info('sockname')
     custom_peer_config = BitBootConfig(
-        bootstrap_nodes=[(listening_host, listening_port)],
+        bootstrap_nodes=[KnownHost(listening_host, listening_port)],
         rate_limit_delay=1.0,
         max_retries=3,
         retry_delay=5.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ uuid = "^1.30"
 kademlia = "^2.2.2"
 twisted = "^22.10.0"
 tenacity = "^8.2.2"
+typing_extensions = ">=4.7"
 
 
 [build-system]


### PR DESCRIPTION
## Summary
- fix DHTManager bootstrap and add support for selecting network/backend
- correct BitBoot initialization and enable multi-network lookup/announce
- expose core classes in top-level package and require modern typing_extensions
- extract KNOWN_HOSTS to structured config with `KnownHost` dataclass