### PR TITLE
refactor DHT configuration and peer announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,21 @@ When you make a network using BitBoot / BitBootPy, you make an entry on the BitT
 
 
 ## Usage
-To use BitBoot, simply create an instance of the AsyncBitBoot class with a unique key, and call the announce and lookup methods to join the network and discover peers. Here's a simple example:
+To use BitBootPy, create a :class:`BitBoot` instance and announce a
+:class:`KnownHost` before looking up peers. Here's a simple example:
 
 ```python
-from bitboot.async_bitboot import AsyncBitBoot
+import asyncio
+from bitbootpy import BitBoot, BitBootConfig, KnownHost
 
 async def main():
-    bot = AsyncBitBoot("unique_key")
-    info_hash = await bot.announce()
-    found_peers = await bot.lookup(info_hash)
-    print("Found peers:", found_peers)
-    bot.stop()
+    bitboot = await BitBoot.create(BitBootConfig())
+    await bitboot.announce_peer("unique_network", KnownHost("127.0.0.1", 6881))
+    await bitboot.lookup("unique_network")
 
 if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-For more examples and details on how to use BitBoot, see the `examples` directory.
+For more examples and details on how to use BitBootPy, see the `examples` directory.
+

--- a/bitbootpy/__init__.py
+++ b/bitbootpy/__init__.py
@@ -5,6 +5,18 @@ This module re-exports the public classes from the core implementation so that
 """
 
 from .core.bitbootpy import BitBoot, BitBootConfig
-from .core.known_hosts import KnownHost
+from .core.known_hosts import (
+    KnownHost,
+    DHTConfig,
+    DHTNetwork,
+    DHTBackend,
+)
 
-__all__ = ["BitBoot", "BitBootConfig", "KnownHost"]
+__all__ = [
+    "BitBoot",
+    "BitBootConfig",
+    "KnownHost",
+    "DHTConfig",
+    "DHTNetwork",
+    "DHTBackend",
+]

--- a/bitbootpy/applications/cli.py
+++ b/bitbootpy/applications/cli.py
@@ -1,20 +1,14 @@
-# BitBootPY - Fully-Decentralized Peer Discovery For P2P Networks
+"""Command line interface for BitBootPY."""
 
 from __future__ import annotations
-from typing import Dict, List, Tuple, Optional, Union, Type, TYPE_CHECKING
-import hashlib
-import datetime
-import json
-from kademlia.network import Server
-# from twisted.internet import reactor, defer, asyncioreactor
-# from twisted.names import client
-from tenacity import retry, wait_fixed, stop_after_attempt
-import logging
-import argparse
-from asyncio import gather, create_task, run
-import sys
 
-from bitbootpy.bitbootpy import BitBoot 
+import argparse
+import json
+import sys
+from asyncio import gather, run
+from typing import List
+
+from bitbootpy import BitBoot, BitBootConfig, KnownHost
 
 
 async def main(argv: List[str]):
@@ -36,11 +30,15 @@ async def main(argv: List[str]):
         help="Lookup peers in the specified network(s)",
     )
     parser.add_argument(
-        "-p",
-        "--port",
+        "--peer-host",
+        default="127.0.0.1",
+        help="Host address of the peer to announce (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--peer-port",
         type=int,
         default=6881,
-        help="Port number to announce (default: 6881)",
+        help="Port number of the peer to announce (default: 6881)",
     )
     parser.add_argument(
         "--continuous",
@@ -59,7 +57,7 @@ async def main(argv: List[str]):
         help="Load network names from a file (one name per line)",
     )
     parser.add_argument(
-       "--print-discovered-peers",
+        "--print-discovered-peers",
         action="store_true",
         help="Print discovered peers to stdout",
     )
@@ -68,9 +66,7 @@ async def main(argv: List[str]):
 
     config = BitBootConfig(print_discovered_peers=args.print_discovered_peers)
 
-
     if args.config:
-        # Load configuration from the file
         with open(args.config, "r") as f:
             loaded_config = json.load(f)
         config = BitBootConfig(**loaded_config)
@@ -78,27 +74,26 @@ async def main(argv: List[str]):
     if args.network_names_file:
         config.load_network_names_from_file(args.network_names_file)
 
-    async with BitBoot.create(config=config) as bitboot:
+    bitboot = await BitBoot.create(config=config)
 
-        async def run_async_tasks():
-            tasks = []
-            if args.announce:
-                for network_name in args.announce:
-                    tasks.append(bitboot.announce(network_name, args.port))
-            if args.lookup:
-                for network_name in args.lookup:
-                    tasks.append(bitboot.lookup(network_name))
-            if args.continuous:
-                for network_name in args.continuous:
-                    tasks.append(bitboot.start_continuous_mode(network_name))
+    tasks = []
+    if args.announce:
+        peer = KnownHost(args.peer_host, args.peer_port)
+        for network_name in args.announce:
+            tasks.append(bitboot.announce_peer(network_name, peer))
+    if args.lookup:
+        for network_name in args.lookup:
+            tasks.append(bitboot.lookup(network_name))
+    if args.continuous:
+        for network_name in args.continuous:
+            tasks.append(bitboot.start_continuous_mode(network_name))
 
-            if tasks:
-                await gather(*tasks)
+    if tasks:
+        await gather(*tasks)
+    else:
+        parser.print_help()
 
-        if args.announce or args.lookup or args.continuous:
-            create_task(run_async_tasks())
-        else:
-            parser.print_help()
-    
+
 if __name__ == "__main__":
     run(main(sys.argv[1:]))
+

--- a/bitbootpy/core/known_hosts.py
+++ b/bitbootpy/core/known_hosts.py
@@ -1,20 +1,53 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Tuple
+from enum import Enum
+
+
+class DHTNetwork(str, Enum):
+    """Enumeration of supported DHT networks."""
+
+    BIT_TORRENT = "bit_torrent"
+    BTC = "btc"
+    SOL = "sol"
+    ETH = "eth"
+    IPFS = "ipfs"
+    ARWEAVE = "arweave"
+
+
+class DHTBackend(str, Enum):
+    """Enumeration of available DHT backends."""
+
+    KADEMLIA = "kademlia"
 
 
 @dataclass(frozen=True)
 class KnownHost:
-    """Representation of a known bootstrap host."""
+    """Representation of a host and port combination."""
+
     host: str
     port: int
+
+    def as_tuple(self) -> Tuple[str, int]:
+        """Return the host/port pair as a ``(host, port)`` tuple."""
+
+        return self.host, self.port
+
+
+@dataclass(frozen=True)
+class DHTConfig:
+    """Configuration describing which DHT network/backend to use and where to listen."""
+
+    network: DHTNetwork = DHTNetwork.BIT_TORRENT
+    backend: DHTBackend = DHTBackend.KADEMLIA
+    listen: KnownHost = KnownHost("0.0.0.0", 5678)
 
 
 # Known bootstrap hosts for various networks. Only the BitTorrent network has
 # real seed nodes at the moment but the structure allows additional networks or
 # backends to be added in the future.
-KNOWN_HOSTS: Dict[str, List[KnownHost]] = {
-    "bit_torrent": [
+KNOWN_HOSTS: Dict[DHTNetwork, List[KnownHost]] = {
+    DHTNetwork.BIT_TORRENT: [
         KnownHost("dht.transmissionbt.com", 6881),
         KnownHost("dht.u-phoria.org", 6881),
         KnownHost("dht.bt.am", 2710),
@@ -27,9 +60,9 @@ KNOWN_HOSTS: Dict[str, List[KnownHost]] = {
         KnownHost("dht.leechers-paradise.org", 6969),
     ],
     # Placeholder entries for additional networks/backends.
-    "btc": [],
-    "sol": [],
-    "eth": [],
-    "ipfs": [],
-    "arweave": [],
+    DHTNetwork.BTC: [],
+    DHTNetwork.SOL: [],
+    DHTNetwork.ETH: [],
+    DHTNetwork.IPFS: [],
+    DHTNetwork.ARWEAVE: [],
 }

--- a/bitbootpy/examples/example.py
+++ b/bitbootpy/examples/example.py
@@ -1,11 +1,17 @@
-import bitbootpy
+"""Basic example demonstrating announcing and looking up peers."""
+
+import asyncio
+
+from bitbootpy import BitBoot, BitBootConfig, KnownHost
+
+
+async def main() -> None:
+    bitboot = await BitBoot.create(BitBootConfig())
+    await bitboot.announce_peer("example_network", KnownHost("127.0.0.1", 6881))
+    await bitboot.lookup("example_network")
+
 
 if __name__ == "__main__":
-    bitboot = BitBoot()
+    asyncio.run(main())
 
-    # Announce peer
-    bitboot.announce_peer("example_network", 6881)
 
-    # Discover peers
-    for discovered_peer in bitboot.lookup("example_network"):
-        print("Discovered peer:", discovered_peer)


### PR DESCRIPTION
## Summary
- introduce `DHTNetwork`/`DHTBackend` enums and `DHTConfig` dataclass with `KnownHost.as_tuple` helper
- refactor `DHTManager` and `BitBoot` APIs to use structured config and `KnownHost` for peer announcements
- update CLI, examples, and documentation to match the new KnownHost-based interface