### PR TITLE
feat: add pluggable DHT backend architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,28 @@ python -m bitbootpy.applications.cli --lookup mynet
 
 Use ``--continuous mynet`` to poll for peers continuously or ``--help`` for all options.
 
+## Built-in DHT networks and extensibility
+
+BitBootPy ships with a small set of built-in DHT network definitions located in
+`bitbootpy/core/dhtnetworks/`. Each module registers a ``DHTNetwork`` instance
+when imported. The registry is populated automatically during startup, but you
+can add your own networks by creating a similar module and ensuring it is
+imported.
+
+For local testing the package also provides a ``local`` network that has no
+bootstrap hosts. Tests and examples can use this lightweight network without
+reaching out to public DHT nodes.
+
+### Using custom DHT backends
+
+BitBootPy supports pluggable DHT backends.  The default implementation uses the
+``kademlia`` library but alternative backends can be registered by inserting a
+factory into :data:`bitbootpy.core.backends.BACKEND_REGISTRY`.  Each
+``DHTNetwork`` specifies the backend it expects via the ``backend`` field.  See
+``bitbootpy/examples/custom_backend.py`` for a minimal in-memory backend
+demonstrating the registration process.
+
+Most built-in network definitions (e.g. Ethereum or Solana) do not ship with
+bootstrap host lists or working backends.  They act as placeholders so that
+projects can supply the necessary dependencies and configuration at runtime.
+

--- a/bitbootpy/__init__.py
+++ b/bitbootpy/__init__.py
@@ -9,7 +9,6 @@ from .core.dht_network import (
     KnownHost,
     DHTConfig,
     DHTNetwork,
-    DHTBackend,
     DHT_NETWORK_REGISTRY,
 )
 from .core.network import Network, NETWORK_REGISTRY
@@ -20,7 +19,6 @@ __all__ = [
     "KnownHost",
     "DHTConfig",
     "DHTNetwork",
-    "DHTBackend",
     "DHT_NETWORK_REGISTRY",
     "Network",
     "NETWORK_REGISTRY",

--- a/bitbootpy/core/backends/__init__.py
+++ b/bitbootpy/core/backends/__init__.py
@@ -1,0 +1,34 @@
+"""Backend registry and built-in backend registrations."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from .base import BaseDHTBackend
+
+BACKEND_REGISTRY: Dict[str, Callable[[], BaseDHTBackend]] = {}
+
+
+def register_backend(name: str, factory: Callable[[], BaseDHTBackend]) -> None:
+    """Register a backend factory under ``name``."""
+    BACKEND_REGISTRY[name] = factory
+
+
+# Register built-in backends
+from .kademlia import KademliaBackend
+register_backend("kademlia", KademliaBackend)
+
+# Optional example backends
+try:  # pragma: no cover - illustrative only
+    from .ethereum_discv5 import EthereumDiscv5Backend
+
+    register_backend("eth-discv5", EthereumDiscv5Backend)
+except Exception:  # pragma: no cover - illustrative only
+    pass
+
+try:  # pragma: no cover - illustrative only
+    from .solana_backend import SolanaBackend
+
+    register_backend("solana", SolanaBackend)
+except Exception:  # pragma: no cover - illustrative only
+    pass

--- a/bitbootpy/core/backends/base.py
+++ b/bitbootpy/core/backends/base.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Abstract base class for pluggable DHT backends.
+
+Backends are lightweight wrappers around third-party libraries that provide
+basic DHT functionality.  Each backend must implement a small async API so the
+:class:`~bitbootpy.core.dht_manager.DHTManager` can interact with it without
+knowing any backend specifics.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Iterable, Tuple
+
+
+class BaseDHTBackend(ABC):
+    """Minimal interface all DHT backends must implement."""
+
+    @abstractmethod
+    async def listen(self, port: int) -> None:
+        """Start listening on the given UDP/TCP port."""
+
+    @abstractmethod
+    async def bootstrap(self, nodes: Iterable[Tuple[str, int]]) -> None:
+        """Bootstrap the DHT using a list of known nodes."""
+
+    @abstractmethod
+    async def get(self, key: bytes) -> Any:
+        """Retrieve a value for ``key`` from the DHT."""
+
+    @abstractmethod
+    async def set(self, key: bytes, value: Any) -> bool:
+        """Store a value for ``key`` on the DHT."""
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Shut down the backend and release all resources."""
+
+    @abstractmethod
+    def get_listening_host(self) -> Tuple[str, int]:
+        """Return the address the backend is listening on."""

--- a/bitbootpy/core/backends/ethereum_discv5.py
+++ b/bitbootpy/core/backends/ethereum_discv5.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Placeholder backend for Ethereum's Discovery v5 protocol.
+
+The implementation here is intentionally minimal and serves primarily as an
+example of how a backend could be wired into BitBootPy.  A fully working
+backend would likely wrap an external library that implements the Discovery v5
+protocol.
+"""
+
+from typing import Any, Iterable, Tuple
+
+from .base import BaseDHTBackend
+
+
+class EthereumDiscv5Backend(BaseDHTBackend):
+    """Non-functional example backend for Ethereum Discovery v5."""
+
+    async def listen(self, port: int) -> None:  # pragma: no cover - illustrative
+        raise NotImplementedError("Ethereum Discovery v5 backend not implemented")
+
+    async def bootstrap(self, nodes: Iterable[Tuple[str, int]]) -> None:  # pragma: no cover - illustrative
+        raise NotImplementedError("Ethereum Discovery v5 backend not implemented")
+
+    async def get(self, key: bytes) -> Any:  # pragma: no cover - illustrative
+        raise NotImplementedError("Ethereum Discovery v5 backend not implemented")
+
+    async def set(self, key: bytes, value: Any) -> bool:  # pragma: no cover - illustrative
+        raise NotImplementedError("Ethereum Discovery v5 backend not implemented")
+
+    def stop(self) -> None:  # pragma: no cover - illustrative
+        pass
+
+    def get_listening_host(self) -> Tuple[str, int]:  # pragma: no cover - illustrative
+        raise NotImplementedError("Ethereum Discovery v5 backend not implemented")

--- a/bitbootpy/core/backends/kademlia.py
+++ b/bitbootpy/core/backends/kademlia.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Kademlia backend implementation wrapping :mod:`kademlia` library."""
+
+from typing import Any, Iterable, Tuple
+from kademlia.network import Server
+
+from .base import BaseDHTBackend
+
+
+class KademliaBackend(BaseDHTBackend):
+    """Thin wrapper around :class:`kademlia.network.Server`."""
+
+    def __init__(self) -> None:
+        self.server = Server()
+
+    async def listen(self, port: int) -> None:
+        await self.server.listen(port)
+
+    async def bootstrap(self, nodes: Iterable[Tuple[str, int]]) -> None:
+        if nodes:
+            await self.server.bootstrap(list(nodes))
+
+    async def get(self, key: bytes) -> Any:
+        return await self.server.get(key)
+
+    async def set(self, key: bytes, value: Any) -> bool:
+        return await self.server.set(key, value)
+
+    def stop(self) -> None:
+        self.server.stop()
+
+    def get_listening_host(self) -> Tuple[str, int]:
+        if not self.server.transport:
+            raise RuntimeError("Kademlia server not started")
+        host, port = self.server.transport.get_extra_info("sockname")
+        return host, port

--- a/bitbootpy/core/backends/solana_backend.py
+++ b/bitbootpy/core/backends/solana_backend.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Placeholder backend for the Solana network.
+
+This backend does not implement actual Solana peer discovery.  It merely
+illustrates how a third-party library could be wrapped to conform to the
+:class:`BaseDHTBackend` interface.
+"""
+
+from typing import Any, Iterable, Tuple
+
+from .base import BaseDHTBackend
+
+
+class SolanaBackend(BaseDHTBackend):
+    """Non-functional example backend for the Solana network."""
+
+    async def listen(self, port: int) -> None:  # pragma: no cover - illustrative
+        raise NotImplementedError("Solana backend not implemented")
+
+    async def bootstrap(self, nodes: Iterable[Tuple[str, int]]) -> None:  # pragma: no cover - illustrative
+        raise NotImplementedError("Solana backend not implemented")
+
+    async def get(self, key: bytes) -> Any:  # pragma: no cover - illustrative
+        raise NotImplementedError("Solana backend not implemented")
+
+    async def set(self, key: bytes, value: Any) -> bool:  # pragma: no cover - illustrative
+        raise NotImplementedError("Solana backend not implemented")
+
+    def stop(self) -> None:  # pragma: no cover - illustrative
+        pass
+
+    def get_listening_host(self) -> Tuple[str, int]:  # pragma: no cover - illustrative
+        raise NotImplementedError("Solana backend not implemented")

--- a/bitbootpy/core/bitbootpy.py
+++ b/bitbootpy/core/bitbootpy.py
@@ -201,7 +201,7 @@ class BitBoot:
 
         for _ in range(num_searches):
             await asyncio.sleep(delay)
-            results = await manager.get_server().get(info_hash)
+            results = await manager.get(info_hash)
             if results:
                 for peer in results:
                     if isinstance(peer, tuple):
@@ -263,7 +263,7 @@ class BitBoot:
 
         info_hash = self._generate_info_hash(network_name)
 
-        await manager.get_server().set(info_hash, f"{peer.host}:{peer.port}")
+        await manager.set(info_hash, f"{peer.host}:{peer.port}")
 
     # -----------------------
     # Continuous Mode

--- a/bitbootpy/core/dht_network.py
+++ b/bitbootpy/core/dht_network.py
@@ -8,14 +8,7 @@ each network carries its bootstrap hosts and backend information.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import Dict, List, Tuple, Optional
-
-
-class DHTBackend(str, Enum):
-    """Enumeration of supported DHT backends."""
-
-    KADEMLIA = "kademlia"
 
 
 @dataclass(frozen=True)
@@ -34,7 +27,7 @@ class DHTNetwork:
     """Description of a DHT network and how to bootstrap it."""
 
     name: str
-    backend: DHTBackend = DHTBackend.KADEMLIA
+    backend: str = "kademlia"
     bootstrap_hosts: List[KnownHost] = field(default_factory=list)
 
 
@@ -82,29 +75,10 @@ class DHTNetworkRegistry:
 DHT_NETWORK_REGISTRY = DHTNetworkRegistry()
 
 
-# Pre-register a few common networks with default bootstrap nodes.  Only the
-# BitTorrent network has real bootstrap nodes at the moment but the registry is
-# ready to hold additional networks as they become available.
-DHT_NETWORK_REGISTRY.add(
-    DHTNetwork(
-        "bit_torrent",
-        bootstrap_hosts=[
-            KnownHost("dht.transmissionbt.com", 6881),
-            KnownHost("dht.u-phoria.org", 6881),
-            KnownHost("dht.bt.am", 2710),
-            KnownHost("dht.ipred.org", 6969),
-            KnownHost("dht.pirateparty.gr", 80),
-            KnownHost("dht.zoink.nl", 80),
-            KnownHost("dht.openbittorrent.com", 80),
-            KnownHost("dht.istole.it", 6969),
-            KnownHost("dht.ccc.de", 80),
-            KnownHost("dht.leechers-paradise.org", 6969),
-        ],
-    )
-)
+# Load all built-in networks which register themselves on import
+from .dhtnetworks import register_all as _register_dht_networks
 
-for name in ["btc", "sol", "eth", "ipfs", "arweave"]:
-    DHT_NETWORK_REGISTRY.add(DHTNetwork(name))
+_register_dht_networks()
 
 
 # ---------------------------------------------------------------------------

--- a/bitbootpy/core/dhtnetworks/__init__.py
+++ b/bitbootpy/core/dhtnetworks/__init__.py
@@ -1,0 +1,18 @@
+"""Built-in DHT network definitions."""
+
+from importlib import import_module
+from typing import List
+
+_BUILTINS: List[str] = [
+    "bittorrent",
+    "btc",
+    "eth",
+    "solana",
+    "arweave",
+    "local",
+]
+
+def register_all() -> None:
+    """Import all built-in DHT network modules so they register themselves."""
+    for name in _BUILTINS:
+        import_module(f"{__name__}.{name}")

--- a/bitbootpy/core/dhtnetworks/arweave.py
+++ b/bitbootpy/core/dhtnetworks/arweave.py
@@ -1,0 +1,10 @@
+"""Definition for the Arweave DHT network.
+
+Currently this is only a stub; no bootstrap hosts or custom backend are
+provided.  Users interested in Arweave integration should register bootstrap
+nodes and an appropriate backend themselves.
+"""
+
+from ..dht_network import DHTNetwork, DHT_NETWORK_REGISTRY
+
+DHT_NETWORK_REGISTRY.add(DHTNetwork("arweave"))

--- a/bitbootpy/core/dhtnetworks/bittorrent.py
+++ b/bitbootpy/core/dhtnetworks/bittorrent.py
@@ -1,0 +1,21 @@
+"""Definition for the BitTorrent DHT network."""
+
+from ..dht_network import DHTNetwork, DHT_NETWORK_REGISTRY, KnownHost
+
+DHT_NETWORK_REGISTRY.add(
+    DHTNetwork(
+        "bit_torrent",
+        bootstrap_hosts=[
+            KnownHost("dht.transmissionbt.com", 6881),
+            KnownHost("dht.u-phoria.org", 6881),
+            KnownHost("dht.bt.am", 2710),
+            KnownHost("dht.ipred.org", 6969),
+            KnownHost("dht.pirateparty.gr", 80),
+            KnownHost("dht.zoink.nl", 80),
+            KnownHost("dht.openbittorrent.com", 80),
+            KnownHost("dht.istole.it", 6969),
+            KnownHost("dht.ccc.de", 80),
+            KnownHost("dht.leechers-paradise.org", 6969),
+        ],
+    )
+)

--- a/bitbootpy/core/dhtnetworks/btc.py
+++ b/bitbootpy/core/dhtnetworks/btc.py
@@ -1,0 +1,9 @@
+"""Definition for the Bitcoin DHT network.
+
+No bootstrap hosts are bundled.  This entry primarily acts as a placeholder so
+that projects can supply their own bootstrap list at runtime.
+"""
+
+from ..dht_network import DHTNetwork, DHT_NETWORK_REGISTRY
+
+DHT_NETWORK_REGISTRY.add(DHTNetwork("btc"))

--- a/bitbootpy/core/dhtnetworks/eth.py
+++ b/bitbootpy/core/dhtnetworks/eth.py
@@ -1,0 +1,10 @@
+"""Definition for the Ethereum DHT network.
+
+No bootstrap hosts are provided and the network requires the optional
+``eth-discv5`` backend.  Users must supply their own list of Discovery v5
+nodes for bootstrapping.
+"""
+
+from ..dht_network import DHTNetwork, DHT_NETWORK_REGISTRY
+
+DHT_NETWORK_REGISTRY.add(DHTNetwork("eth", backend="eth-discv5"))

--- a/bitbootpy/core/dhtnetworks/local.py
+++ b/bitbootpy/core/dhtnetworks/local.py
@@ -1,0 +1,8 @@
+"""A local in-memory DHT network used for tests.
+
+No bootstrap hosts are defined and the default Kademlia backend is used.
+"""
+
+from ..dht_network import DHTNetwork, DHT_NETWORK_REGISTRY
+
+DHT_NETWORK_REGISTRY.add(DHTNetwork("local"))

--- a/bitbootpy/core/dhtnetworks/solana.py
+++ b/bitbootpy/core/dhtnetworks/solana.py
@@ -1,0 +1,10 @@
+"""Definition for the Solana DHT network.
+
+This module registers the ``solana`` network which expects a backend named
+``solana``.  The provided backend is a placeholder and users need to supply
+bootstrap hosts separately.
+"""
+
+from ..dht_network import DHTNetwork, DHT_NETWORK_REGISTRY
+
+DHT_NETWORK_REGISTRY.add(DHTNetwork("solana", backend="solana"))

--- a/bitbootpy/examples/custom_backend.py
+++ b/bitbootpy/examples/custom_backend.py
@@ -1,0 +1,53 @@
+"""Example showing how to register and use a custom DHT backend."""
+
+import asyncio
+from typing import Iterable, Tuple, Any
+
+from bitbootpy.core.backends import BACKEND_REGISTRY, BaseDHTBackend
+from bitbootpy.core.dht_network import DHT_NETWORK_REGISTRY, DHTNetwork, DHTConfig
+from bitbootpy.core.dht_manager import DHTManager
+
+
+class InMemoryBackend(BaseDHTBackend):
+    """Trivial backend storing values in a local dictionary.
+
+    This backend is not distributed; it merely demonstrates how a backend fits
+    into the BitBootPy architecture.  Two peers using this backend would need to
+    share the same Python object to communicate.
+    """
+
+    def __init__(self) -> None:
+        self.store = {}
+        self.addr = ("127.0.0.1", 0)
+
+    async def listen(self, port: int) -> None:
+        self.addr = ("127.0.0.1", port)
+
+    async def bootstrap(self, nodes: Iterable[Tuple[str, int]]) -> None:
+        pass
+
+    async def get(self, key: bytes) -> Any:
+        return self.store.get(key)
+
+    async def set(self, key: bytes, value: Any) -> bool:
+        self.store[key] = value
+        return True
+
+    def stop(self) -> None:
+        pass
+
+    def get_listening_host(self) -> Tuple[str, int]:
+        return self.addr
+
+
+async def main() -> None:
+    BACKEND_REGISTRY["inmemory"] = InMemoryBackend
+    net = DHT_NETWORK_REGISTRY.add(DHTNetwork("demo", backend="inmemory"))
+    manager = await DHTManager.create(config=DHTConfig(network=net))
+    await manager.set(b"hello", "world")
+    print(await manager.get(b"hello"))
+    manager.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_peer_discovery.py
+++ b/tests/test_peer_discovery.py
@@ -18,10 +18,15 @@ def _compat_coroutine(func):
 asyncio.coroutine = _compat_coroutine
 
 from bitbootpy.core.bitbootpy import BitBoot, BitBootConfig
-from bitbootpy.core.dht_network import KnownHost
+from bitbootpy.core.dht_network import (
+    KnownHost,
+    DHT_NETWORK_REGISTRY,
+    DHTConfig,
+)
+from bitbootpy.core.network import NETWORK_REGISTRY
 
 
-class DummyServer:
+class DummyBackend:
     def __init__(self):
         self.store = {}
 
@@ -41,23 +46,28 @@ class DummyServer:
     def stop(self):
         pass
 
+    def get_listening_host(self):
+        return ("127.0.0.1", 0)
+
 
 @pytest.mark.asyncio
 async def test_peer_discovery_dummy_network():
-    dummy = DummyServer()
-    node_a = BitBoot()
-    node_b = BitBoot()
-    node_a._dht_manager.get_manager(node_a._config.dht.network.name)._server = dummy
-    node_b._dht_manager.get_manager(node_b._config.dht.network.name)._server = dummy
+    dummy = DummyBackend()
+    local_net = DHT_NETWORK_REGISTRY.get("local")
+    test_network = NETWORK_REGISTRY.create("test_topic", [local_net])
+    config_a = BitBootConfig(dht=DHTConfig(network=local_net))
+    config_b = BitBootConfig(dht=DHTConfig(network=local_net))
+    node_a = BitBoot(config=config_a)
+    node_b = BitBoot(config=config_b)
+    node_a._dht_manager.get_manager(local_net.name)._backend = dummy
+    node_b._dht_manager.get_manager(local_net.name)._backend = dummy
 
     peer = KnownHost("127.0.0.1", 1234)
-    await node_a.announce_peer("test_topic", peer)
-    await node_b.lookup("test_topic", num_searches=1, delay=0)
+    await node_a.announce_peer(test_network, peer)
+    await node_b.lookup(test_network, num_searches=1, delay=0)
 
     discovered = {
-        p
-        for peers in node_b._discovered_peers["test_topic"].values()
-        for p in peers
+        p for peers in node_b._discovered_peers[test_network.name].values() for p in peers
     }
     assert peer.as_tuple() in discovered
 


### PR DESCRIPTION
## Summary
- introduce pluggable DHT backend interface and registry with default kademlia backend
- allow networks to specify backend names and document bootstrap expectations
- refactor DHT manager and examples to use backend abstraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9f8bfd15c83228bc0098408defeba