### PR TITLE
Add wallet helpers and integrate with backends

### DIFF
--- a/bitbootpy/core/backends/ethereum_discv5.py
+++ b/bitbootpy/core/backends/ethereum_discv5.py
@@ -10,11 +10,17 @@ protocol.
 
 from typing import Any, Iterable, Tuple
 
+from ..wallets import get_eth_key
 from .base import BaseDHTBackend
 
 
 class EthereumDiscv5Backend(BaseDHTBackend):
     """Non-functional example backend for Ethereum Discovery v5."""
+
+    def __init__(self) -> None:
+        # Load the private key from the environment.  Real implementations would
+        # use this key to identify the node on the Ethereum network.
+        self.key = get_eth_key()
 
     async def listen(self, port: int) -> None:  # pragma: no cover - illustrative
         raise NotImplementedError("Ethereum Discovery v5 backend not implemented")

--- a/bitbootpy/core/backends/solana_backend.py
+++ b/bitbootpy/core/backends/solana_backend.py
@@ -9,11 +9,16 @@ illustrates how a third-party library could be wrapped to conform to the
 
 from typing import Any, Iterable, Tuple
 
+from ..wallets import get_solana_keypair
 from .base import BaseDHTBackend
 
 
 class SolanaBackend(BaseDHTBackend):
     """Non-functional example backend for the Solana network."""
+
+    def __init__(self) -> None:
+        # Load the Solana keypair from the environment to identify the node.
+        self.keypair = get_solana_keypair()
 
     async def listen(self, port: int) -> None:  # pragma: no cover - illustrative
         raise NotImplementedError("Solana backend not implemented")

--- a/bitbootpy/core/wallets.py
+++ b/bitbootpy/core/wallets.py
@@ -1,0 +1,56 @@
+"""Helpers for loading blockchain key material from environment variables."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from bitcoinlib.keys import Key as BTCKey
+from eth_keys import keys as eth_keys
+from solders.keypair import Keypair as SolanaKeypair
+from arweave import Wallet
+
+
+def _require_env(var: str) -> str:
+    value = os.getenv(var)
+    if not value:
+        raise RuntimeError(f"{var} environment variable is not set")
+    return value
+
+
+def get_btc_key() -> BTCKey:
+    """Return a Bitcoin ``Key`` from ``BITBOOTPY_BTC_KEY``."""
+    key_str = _require_env("BITBOOTPY_BTC_KEY")
+    return BTCKey(key_str)
+
+
+def get_eth_key() -> eth_keys.PrivateKey:
+    """Return an Ethereum ``PrivateKey`` from ``BITBOOTPY_ETH_KEY``."""
+    key_str = _require_env("BITBOOTPY_ETH_KEY")
+    if key_str.startswith("0x") or key_str.startswith("0X"):
+        key_str = key_str[2:]
+    key_bytes = bytes.fromhex(key_str)
+    return eth_keys.PrivateKey(key_bytes)
+
+
+def get_solana_keypair() -> SolanaKeypair:
+    """Return a Solana ``Keypair`` from ``BITBOOTPY_SOLANA_KEYPAIR``."""
+    key_str = _require_env("BITBOOTPY_SOLANA_KEYPAIR")
+    try:
+        data = json.loads(key_str)
+        if isinstance(data, list):
+            secret = bytes(data)
+        else:
+            raise ValueError("Solana keypair JSON must be an array of integers")
+    except json.JSONDecodeError:
+        from base58 import b58decode
+
+        secret = b58decode(key_str)
+    return SolanaKeypair.from_bytes(secret)
+
+
+def get_arweave_wallet() -> Wallet:
+    """Return an Arweave ``Wallet`` from ``BITBOOTPY_ARWEAVE_WALLET``."""
+    key_str = _require_env("BITBOOTPY_ARWEAVE_WALLET")
+    jwk_data = json.loads(key_str)
+    return Wallet.from_data(jwk_data)

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -1,0 +1,96 @@
+import base64
+import json
+import os
+
+import pytest
+from bitcoinlib.keys import Key as BTCKey
+from eth_keys import keys as eth_keys
+from solders.keypair import Keypair as SolanaKeypair
+from arweave import Wallet
+from Crypto.PublicKey import RSA
+
+from bitbootpy.core.wallets import (
+    get_btc_key,
+    get_eth_key,
+    get_solana_keypair,
+    get_arweave_wallet,
+)
+from bitbootpy.core.backends.ethereum_discv5 import EthereumDiscv5Backend
+from bitbootpy.core.backends.solana_backend import SolanaBackend
+
+
+def test_missing_env(monkeypatch):
+    monkeypatch.delenv("BITBOOTPY_BTC_KEY", raising=False)
+    monkeypatch.delenv("BITBOOTPY_ETH_KEY", raising=False)
+    monkeypatch.delenv("BITBOOTPY_SOLANA_KEYPAIR", raising=False)
+    monkeypatch.delenv("BITBOOTPY_ARWEAVE_WALLET", raising=False)
+
+    with pytest.raises(RuntimeError):
+        get_btc_key()
+    with pytest.raises(RuntimeError):
+        get_eth_key()
+    with pytest.raises(RuntimeError):
+        get_solana_keypair()
+    with pytest.raises(RuntimeError):
+        get_arweave_wallet()
+
+
+def test_get_btc_key(monkeypatch):
+    k = BTCKey()
+    monkeypatch.setenv("BITBOOTPY_BTC_KEY", k.wif())
+    loaded = get_btc_key()
+    assert isinstance(loaded, BTCKey)
+    assert loaded.wif() == k.wif()
+
+
+def test_get_eth_key(monkeypatch):
+    pk = eth_keys.PrivateKey(os.urandom(32))
+    monkeypatch.setenv("BITBOOTPY_ETH_KEY", pk.to_hex())
+    loaded = get_eth_key()
+    assert isinstance(loaded, eth_keys.PrivateKey)
+    assert loaded == pk
+
+
+def test_get_solana_keypair(monkeypatch):
+    kp = SolanaKeypair()
+    monkeypatch.setenv("BITBOOTPY_SOLANA_KEYPAIR", json.dumps(list(bytes(kp))))
+    loaded = get_solana_keypair()
+    assert isinstance(loaded, SolanaKeypair)
+    assert bytes(loaded) == bytes(kp)
+
+
+def _b64(x: bytes) -> str:
+    return base64.urlsafe_b64encode(x).decode().rstrip("=")
+
+
+def test_get_arweave_wallet(monkeypatch):
+    k = RSA.generate(1024)
+    jwk = {
+        "kty": "RSA",
+        "n": _b64(k.n.to_bytes((k.n.bit_length()+7)//8, "big")),
+        "e": _b64(k.e.to_bytes((k.e.bit_length()+7)//8, "big")),
+        "d": _b64(k.d.to_bytes((k.d.bit_length()+7)//8, "big")),
+        "p": _b64(k.p.to_bytes((k.p.bit_length()+7)//8, "big")),
+        "q": _b64(k.q.to_bytes((k.q.bit_length()+7)//8, "big")),
+        "dp": _b64((k.d % (k.p-1)).to_bytes((k.d % (k.p-1)).bit_length()//8+1, "big")),
+        "dq": _b64((k.d % (k.q-1)).to_bytes((k.d % (k.q-1)).bit_length()//8+1, "big")),
+        "qi": _b64(pow(k.q, -1, k.p).to_bytes((pow(k.q,-1,k.p).bit_length()+7)//8, "big")),
+    }
+    monkeypatch.setenv("BITBOOTPY_ARWEAVE_WALLET", json.dumps(jwk))
+    loaded = get_arweave_wallet()
+    assert isinstance(loaded, Wallet)
+    assert loaded.address == Wallet.from_data(jwk).address
+
+
+def test_ethereum_backend_uses_helper(monkeypatch):
+    pk = eth_keys.PrivateKey(os.urandom(32))
+    monkeypatch.setenv("BITBOOTPY_ETH_KEY", pk.to_hex())
+    backend = EthereumDiscv5Backend()
+    assert backend.key == pk
+
+
+def test_solana_backend_uses_helper(monkeypatch):
+    kp = SolanaKeypair()
+    monkeypatch.setenv("BITBOOTPY_SOLANA_KEYPAIR", json.dumps(list(bytes(kp))))
+    backend = SolanaBackend()
+    assert bytes(backend.keypair) == bytes(kp)


### PR DESCRIPTION
## Summary
- add wallet utilities to parse keys for BTC, ETH, Solana and Arweave from environment variables
- wire Ethereum and Solana backends to load their keys on construction
- cover wallet helpers and backend integration with comprehensive tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa5af6b73c83229c1e98c1c6386404