### PR TITLE
Add Bitcoin backend with RPC storage

### DIFF
--- a/bitbootpy/core/backends/__init__.py
+++ b/bitbootpy/core/backends/__init__.py
@@ -32,3 +32,10 @@ try:  # pragma: no cover - illustrative only
     register_backend("solana", SolanaBackend)
 except Exception:  # pragma: no cover - illustrative only
     pass
+
+try:  # pragma: no cover - illustrative only
+    from .bitcoin_backend import BitcoinBackend
+
+    register_backend("bitcoin", BitcoinBackend)
+except Exception:  # pragma: no cover - illustrative only
+    pass

--- a/bitbootpy/core/backends/bitcoin_backend.py
+++ b/bitbootpy/core/backends/bitcoin_backend.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+"""Bitcoin backend storing key/value pairs in ``OP_RETURN`` outputs.
+
+This backend embeds BitBootPy data directly into the Bitcoin blockchain by
+tagging ``OP_RETURN`` outputs with a unique prefix.  Values are retrieved by
+scanning recent blocks for the latest matching entry and stored by
+broadcasting a minimal transaction containing the encoded data.
+
+.. warning::
+   Publishing data to Bitcoin requires transaction fees and permanently
+   reveals the information.  Anyone running this backend must ensure they are
+   comfortable with the costs and the public nature of the blockchain.
+"""
+
+import asyncio
+import os
+from typing import Any, Iterable, Tuple
+
+from bitcoin.rpc import RawProxy
+
+from ..wallets import get_btc_key, get_btc_rpc_url
+from .base import BaseDHTBackend
+
+
+class BitcoinBackend(BaseDHTBackend):
+    """Backend that stores BitBootPy records on the Bitcoin blockchain."""
+
+    PREFIX = b"BitBootPy:"
+
+    def __init__(self, rpc_url: str | None = None) -> None:
+        self.key = get_btc_key()
+        self.rpc_url = rpc_url or get_btc_rpc_url()
+        self.proxy = RawProxy(service_url=self.rpc_url)
+        self._host: Tuple[str, int] = ("0.0.0.0", 0)
+        self._nodes: list[Tuple[str, int]] = []
+
+    async def listen(self, port: int) -> None:  # pragma: no cover - networked
+        self._host = ("0.0.0.0", port)
+
+    async def bootstrap(self, nodes: Iterable[Tuple[str, int]]) -> None:
+        """Bootstrap using explicit nodes or fallback DNS seeds."""
+
+        supplied = list(nodes)
+        if supplied:
+            self._nodes = supplied
+            return
+
+        # Only query DNS seeds when no nodes are explicitly supplied.  These
+        # seeds operate standard Bitcoin ports.
+        seeds = [
+            "seed.bitcoin.sipa.be",
+            "dnsseed.bluematt.me",
+            "seed.bitcoinstats.com",
+            "seed.bitcoin.jonasschnelli.ch",
+        ]
+        self._nodes = [(host, 8333) for host in seeds]
+
+    async def get(self, key: bytes) -> Any:
+        """Return the most recent value stored for ``key``.
+
+        The backend scans the last 100 blocks for ``OP_RETURN`` outputs tagged
+        with the BitBootPy prefix and returns the latest matching value.
+        """
+
+        def _scan() -> Any:
+            prefix = self.PREFIX + key + b":"
+            best: bytes | None = None
+            height = self.proxy.getblockcount()
+            start = max(0, height - 100)
+            for h in range(height, start, -1):
+                blockhash = self.proxy.getblockhash(h)
+                block = self.proxy.getblock(blockhash, 2)
+                for tx in block.get("tx", []):
+                    for vout in tx.get("vout", []):
+                        spk = vout.get("scriptPubKey", {})
+                        if spk.get("type") == "nulldata":
+                            hexdata = spk.get("hex", "")[2:]
+                            data = bytes.fromhex(hexdata)
+                            if data.startswith(prefix):
+                                best = data[len(prefix) :]
+                                break
+            return best
+
+        return await asyncio.to_thread(_scan)
+
+    async def set(self, key: bytes, value: Any) -> bool:
+        """Encode ``key`` and ``value`` in an ``OP_RETURN`` output.
+
+        The transaction is funded by the connected node and signed locally with
+        the private key supplied by :func:`get_btc_key`.
+        """
+
+        if isinstance(value, bytes):
+            value_bytes = value
+        elif isinstance(value, str):
+            value_bytes = value.encode()
+        else:
+            value_bytes = str(value).encode()
+
+        payload = (self.PREFIX + key + b":" + value_bytes).hex()
+
+        def _broadcast() -> bool:
+            raw = self.proxy.createrawtransaction([], [{"data": payload}])
+            funded = self.proxy.fundrawtransaction(raw)["hex"]
+            signed = self.proxy.signrawtransactionwithkey(
+                funded, [self.key.wif()]
+            )["hex"]
+            txid = self.proxy.sendrawtransaction(signed)
+            return bool(txid)
+
+        return await asyncio.to_thread(_broadcast)
+
+    def stop(self) -> None:  # pragma: no cover - networked
+        pass
+
+    def get_listening_host(self) -> Tuple[str, int]:
+        return self._host
+

--- a/bitbootpy/core/wallets.py
+++ b/bitbootpy/core/wallets.py
@@ -24,6 +24,11 @@ def get_btc_key() -> BTCKey:
     return BTCKey(key_str)
 
 
+def get_btc_rpc_url() -> str:
+    """Return the Bitcoin RPC URL from ``BITBOOTPY_BTC_RPC_URL``."""
+    return _require_env("BITBOOTPY_BTC_RPC_URL")
+
+
 def get_eth_key() -> eth_keys.PrivateKey:
     """Return an Ethereum ``PrivateKey`` from ``BITBOOTPY_ETH_KEY``."""
     key_str = _require_env("BITBOOTPY_ETH_KEY")

--- a/poetry.lock
+++ b/poetry.lock
@@ -253,6 +253,18 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
+name = "python-bitcoinlib"
+version = "0.12.2"
+description = "The Swiss Army Knife of the Bitcoin protocol."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "python-bitcoinlib-0.12.2.tar.gz", hash = "sha256:c65ab61427c77c38d397bfc431f71d86fd355b453a536496ec3fcb41bd10087d"},
+    {file = "python_bitcoinlib-0.12.2-py3-none-any.whl", hash = "sha256:2f29a9f475f21c12169b3a6cc8820f34f11362d7ff1200a5703dce3e4e903a44"},
+]
+
+[[package]]
 name = "rpcudp"
 version = "4.0.2"
 description = "Asynchronous RPC via UDP"
@@ -506,4 +518,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "7af75b22ebb3941e6e479c5019418401d4afe5eac2be850157a2b7c683e5f4b3"
+content-hash = "8caf456394d11afbf69804e8046439eb04088604c235b4f6b846025830200c94"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ kademlia = "^2.2.2"
 twisted = "^22.10.0"
 tenacity = "^8.2.2"
 typing_extensions = ">=4.7"
+python-bitcoinlib = "^0.12.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -11,6 +11,7 @@ from Crypto.PublicKey import RSA
 
 from bitbootpy.core.wallets import (
     get_btc_key,
+    get_btc_rpc_url,
     get_eth_key,
     get_solana_keypair,
     get_arweave_wallet,
@@ -21,12 +22,15 @@ from bitbootpy.core.backends.solana_backend import SolanaBackend
 
 def test_missing_env(monkeypatch):
     monkeypatch.delenv("BITBOOTPY_BTC_KEY", raising=False)
+    monkeypatch.delenv("BITBOOTPY_BTC_RPC_URL", raising=False)
     monkeypatch.delenv("BITBOOTPY_ETH_KEY", raising=False)
     monkeypatch.delenv("BITBOOTPY_SOLANA_KEYPAIR", raising=False)
     monkeypatch.delenv("BITBOOTPY_ARWEAVE_WALLET", raising=False)
 
     with pytest.raises(RuntimeError):
         get_btc_key()
+    with pytest.raises(RuntimeError):
+        get_btc_rpc_url()
     with pytest.raises(RuntimeError):
         get_eth_key()
     with pytest.raises(RuntimeError):
@@ -41,6 +45,12 @@ def test_get_btc_key(monkeypatch):
     loaded = get_btc_key()
     assert isinstance(loaded, BTCKey)
     assert loaded.wif() == k.wif()
+
+
+def test_get_btc_rpc_url(monkeypatch):
+    url = "http://localhost:8332"
+    monkeypatch.setenv("BITBOOTPY_BTC_RPC_URL", url)
+    assert get_btc_rpc_url() == url
 
 
 def test_get_eth_key(monkeypatch):


### PR DESCRIPTION
## Summary
- add python-bitcoinlib dependency and RPC URL helper
- implement Bitcoin backend storing values in OP_RETURN outputs
- test wallet helpers including RPC URL retrieval

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa993f7e48832292685690ba7e2736