### PR TITLE
Add Ethereum contract backend with discovery support

### DIFF
--- a/bitbootpy/core/backends/__init__.py
+++ b/bitbootpy/core/backends/__init__.py
@@ -20,9 +20,9 @@ register_backend("kademlia", KademliaBackend)
 
 # Optional example backends
 try:  # pragma: no cover - illustrative only
-    from .ethereum_discv5 import EthereumDiscv5Backend
+    from .ethereum_backend import EthereumBackend
 
-    register_backend("eth-discv5", EthereumDiscv5Backend)
+    register_backend("ethereum", EthereumBackend)
 except Exception:  # pragma: no cover - illustrative only
     pass
 

--- a/bitbootpy/core/backends/ethereum_backend.py
+++ b/bitbootpy/core/backends/ethereum_backend.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Iterable, Tuple
+
+from web3 import Web3
+
+try:  # discovery v5 is optional
+    from ddht import DiscoveryService  # type: ignore
+except Exception:  # pragma: no cover - optional
+    DiscoveryService = None  # type: ignore
+
+from ..wallets import get_eth_key
+from .base import BaseDHTBackend
+
+
+class EthereumBackend(BaseDHTBackend):
+    """Backend storing records in an Ethereum smart contract.
+
+    The backend optionally uses Discovery v5 (via ``ddht``) to maintain a table
+    of peers.  If the discovery service is unavailable, contract calls are still
+    performed normally.
+    """
+
+    ABI = [
+        {
+            "inputs": [
+                {"internalType": "bytes32", "name": "key", "type": "bytes32"}
+            ],
+            "name": "get",
+            "outputs": [
+                {"internalType": "bytes", "name": "", "type": "bytes"}
+            ],
+            "stateMutability": "view",
+            "type": "function",
+        },
+        {
+            "inputs": [
+                {"internalType": "bytes32", "name": "key", "type": "bytes32"},
+                {"internalType": "bytes", "name": "value", "type": "bytes"},
+            ],
+            "name": "set",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function",
+        },
+    ]
+
+    def __init__(
+        self, rpc_url: str | None = None, contract_address: str | None = None
+    ) -> None:
+        self.key = get_eth_key()
+        self.rpc_url = rpc_url or os.getenv("BITBOOTPY_ETH_RPC")
+        if not self.rpc_url:
+            raise RuntimeError("BITBOOTPY_ETH_RPC environment variable is not set")
+        self.w3 = Web3(Web3.HTTPProvider(self.rpc_url))
+        address = contract_address or os.getenv("BITBOOTPY_ETH_CONTRACT")
+        if not address:
+            raise RuntimeError("BITBOOTPY_ETH_CONTRACT environment variable is not set")
+        self.contract = self.w3.eth.contract(
+            address=Web3.to_checksum_address(address), abi=self.ABI
+        )
+        self.account = self.key.public_key.to_checksum_address()
+        self._host: Tuple[str, int] = ("0.0.0.0", 0)
+        self._nodes: list[Tuple[str, int]] = []
+        self._discovery = None
+        if DiscoveryService is not None:
+            try:  # pragma: no cover - networked
+                self._discovery = DiscoveryService(self.key.to_bytes())
+            except Exception:
+                self._discovery = None
+
+    async def listen(self, port: int) -> None:  # pragma: no cover - networked
+        self._host = ("0.0.0.0", port)
+        if self._discovery is not None:
+            try:
+                await self._discovery.listen(port)
+            except Exception:
+                self._discovery = None
+
+    async def bootstrap(self, nodes: Iterable[Tuple[str, int]]) -> None:
+        self._nodes = list(nodes)
+        if self._discovery is not None:
+            for host, udp_port in self._nodes:
+                try:
+                    self._discovery.add_peer((host, udp_port))
+                except Exception:
+                    continue
+
+    async def get(self, key: bytes) -> Any:
+        key_bytes = key if len(key) == 32 else Web3.keccak(key)
+
+        def _call() -> Any:
+            return self.contract.functions.get(key_bytes).call()
+
+        return await asyncio.to_thread(_call)
+
+    async def set(self, key: bytes, value: Any) -> bool:
+        key_bytes = key if len(key) == 32 else Web3.keccak(key)
+        if isinstance(value, bytes):
+            data = value
+        elif isinstance(value, str):
+            data = value.encode()
+        else:
+            data = str(value).encode()
+
+        def _send() -> bool:
+            tx = self.contract.functions.set(key_bytes, data).build_transaction(
+                {
+                    "from": self.account,
+                    "nonce": self.w3.eth.get_transaction_count(self.account),
+                    "gas": 200000,
+                    "gasPrice": self.w3.eth.gas_price,
+                }
+            )
+            signed = self.w3.eth.account.sign_transaction(
+                tx, private_key=self.key.to_bytes()
+            )
+            tx_hash = self.w3.eth.send_raw_transaction(signed.rawTransaction)
+            receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash)
+            return receipt.status == 1
+
+        return await asyncio.to_thread(_send)
+
+    def stop(self) -> None:  # pragma: no cover - networked
+        if self._discovery is not None:
+            try:
+                self._discovery.stop()
+            except Exception:
+                pass
+
+    def get_listening_host(self) -> Tuple[str, int]:
+        return self._host

--- a/bitbootpy/core/dhtnetworks/eth.py
+++ b/bitbootpy/core/dhtnetworks/eth.py
@@ -1,10 +1,10 @@
 """Definition for the Ethereum DHT network.
 
-No bootstrap hosts are provided and the network requires the optional
-``eth-discv5`` backend.  Users must supply their own list of Discovery v5
-nodes for bootstrapping.
+The network stores records in a smart contract and can optionally leverage
+Ethereum's Discovery v5 protocol for peer management.  Users must supply their
+own list of bootstrap nodes when using discovery.
 """
 
 from ..dht_network import DHTNetwork, DHT_NETWORK_REGISTRY
 
-DHT_NETWORK_REGISTRY.add(DHTNetwork("eth", backend="eth-discv5"))
+DHT_NETWORK_REGISTRY.add(DHTNetwork("eth", backend="ethereum"))

--- a/bitbootpy/examples/example.py
+++ b/bitbootpy/examples/example.py
@@ -1,17 +1,17 @@
-"""Basic example demonstrating announcing and looking up peers."""
+"""Basic example showing how to store and retrieve a value."""
 
 import asyncio
 
-from bitbootpy import BitBoot, BitBootConfig, KnownHost
+from bitbootpy import BitBoot, BitBootConfig
 
 
 async def main() -> None:
     bitboot = await BitBoot.create(BitBootConfig())
-    await bitboot.announce_peer("example_network", KnownHost("127.0.0.1", 6881))
-    await bitboot.lookup("example_network")
+    manager = bitboot._dht_manager.get_manager(bitboot._config.dht.network.name)
+    await manager.set(b"example-key", b"example-value")
+    value = await manager.get(b"example-key")
+    print("Retrieved:", value)
 
 
 if __name__ == "__main__":
     asyncio.run(main())
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ twisted = "^22.10.0"
 tenacity = "^8.2.2"
 typing_extensions = ">=4.7"
 python-bitcoinlib = "^0.12.2"
+web3 = "^7.0"
+ddht = "*"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- add Web3 and optional ddht dependencies
- implement Ethereum backend using contract storage and optional Discovery v5
- update network registration and example to store and retrieve values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaa4335ef48322928324e5a55ef4d0