### PR TITLE
Add blockchain backend examples and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,46 @@ Most built-in network definitions (e.g. Ethereum or Solana) do not ship with
 bootstrap host lists or working backends.  They act as placeholders so that
 projects can supply the necessary dependencies and configuration at runtime.
 
+## Blockchain backends
+
+BitBootPy includes optional backends that persist DHT records directly on
+popular blockchains.  Using these backends requires additional dependencies and
+environment variables and will incur on-chain transaction fees whenever a value
+is stored.  For development, always prefer running against testnets or local
+nodes to avoid spending real funds and publishing data permanently.
+
+### Bitcoin
+
+- **Environment**: ``BITBOOTPY_BTC_KEY`` (WIF private key),
+  ``BITBOOTPY_BTC_RPC_URL`` (JSON-RPC endpoint)
+- **Dependency**: ``python-bitcoinlib``
+- **Fees**: ``set`` writes an ``OP_RETURN`` transaction and pays the Bitcoin
+  network fee.  Data is permanent and publicly visible.
+
+### Ethereum
+
+- **Environment**: ``BITBOOTPY_ETH_KEY`` (hex private key), ``BITBOOTPY_ETH_RPC``
+  (RPC URL), ``BITBOOTPY_ETH_CONTRACT`` (storage contract address)
+- **Dependencies**: ``web3`` and optional ``ddht`` for Discovery v5
+- **Fees**: ``set`` submits a transaction to the contract and consumes gas.
+
+### Solana
+
+- **Environment**: ``BITBOOTPY_SOLANA_KEYPAIR`` (JSON or base58 keypair),
+  optional ``BITBOOTPY_SOLANA_RPC`` (RPC URL)
+- **Dependency**: ``solana``
+- **Fees**: ``set`` creates or updates an account and pays lamports for rent
+  and transaction fees.
+
+### Arweave
+
+- **Environment**: ``BITBOOTPY_ARWEAVE_WALLET`` (JWK wallet JSON), optional
+  ``BITBOOTPY_ARWEAVE_GATEWAY`` (gateway URL)
+- **Dependency**: ``arweave-python-client``
+- **Fees**: ``set`` publishes a transaction requiring AR tokens.
+
+**Warning**: Interacting with mainnet blockchains costs real cryptocurrency and
+cannot be undone.  Use test networks such as Bitcoin ``regtest``/``testnet``,
+Ethereum ``Sepolia``/``Goerli``, Solana ``devnet``, or the Arweave testnet
+while developing.
+

--- a/bitbootpy/core/backends/__init__.py
+++ b/bitbootpy/core/backends/__init__.py
@@ -39,3 +39,10 @@ try:  # pragma: no cover - illustrative only
     register_backend("bitcoin", BitcoinBackend)
 except Exception:  # pragma: no cover - illustrative only
     pass
+
+try:  # pragma: no cover - illustrative only
+    from .arweave_backend import ArweaveBackend
+
+    register_backend("arweave", ArweaveBackend)
+except Exception:  # pragma: no cover - illustrative only
+    pass

--- a/bitbootpy/core/backends/arweave_backend.py
+++ b/bitbootpy/core/backends/arweave_backend.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Arweave backend storing key/value pairs as transactions."""
+
+import asyncio
+import base64
+import json
+import os
+import urllib.request
+from typing import Any, Iterable, Tuple, List
+
+from arweave import Transaction
+
+from ..wallets import get_arweave_wallet
+from .base import BaseDHTBackend
+
+
+class ArweaveBackend(BaseDHTBackend):
+    """Backend that stores BitBootPy records on the Arweave blockchain."""
+
+    TAG_NAME = "BitBootPy-Key"
+
+    def __init__(self, gateway_url: str | None = None) -> None:
+        self.wallet = get_arweave_wallet()
+        self.gateway_url = gateway_url or os.getenv(
+            "BITBOOTPY_ARWEAVE_GATEWAY", "https://arweave.net"
+        )
+        self._host: Tuple[str, int] = ("0.0.0.0", 0)
+        self._nodes: List[Tuple[str, int]] = []
+
+    async def listen(self, port: int) -> None:
+        self._host = ("0.0.0.0", port)
+
+    async def bootstrap(self, nodes: Iterable[Tuple[str, int]]) -> None:
+        self._nodes = list(nodes)
+
+    async def get(self, key: bytes) -> Any:
+        key_tag = base64.b64encode(key).decode()
+
+        def _query() -> Any:
+            q = {
+                "query": (
+                    "query($key:String!){" "transactions(tags:[{name:\"%s\",values:[$key]}],sort:HEIGHT_DESC,first:1){" "edges{node{id}}}}"
+                    % self.TAG_NAME
+                ),
+                "variables": {"key": key_tag},
+            }
+            data = json.dumps(q).encode()
+            req = urllib.request.Request(
+                self.gateway_url.rstrip("/") + "/graphql",
+                data=data,
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req) as resp:
+                result = json.load(resp)
+            edges = result.get("data", {}).get("transactions", {}).get("edges", [])
+            if not edges:
+                return None
+            tx_id = edges[0]["node"]["id"]
+            with urllib.request.urlopen(
+                self.gateway_url.rstrip("/") + "/" + tx_id
+            ) as resp:
+                return resp.read()
+
+        return await asyncio.to_thread(_query)
+
+    async def set(self, key: bytes, value: Any) -> bool:
+        if isinstance(value, bytes):
+            data = value
+        elif isinstance(value, str):
+            data = value.encode()
+        else:
+            data = str(value).encode()
+        key_tag = base64.b64encode(key).decode()
+
+        def _send() -> bool:
+            tx = Transaction(self.wallet, data=data)
+            tx.add_tag(self.TAG_NAME, key_tag)
+            tx.sign()
+            tx.send()
+            return True
+
+        return await asyncio.to_thread(_send)
+
+    def stop(self) -> None:
+        pass
+
+    def get_listening_host(self) -> Tuple[str, int]:
+        return self._host

--- a/bitbootpy/core/dhtnetworks/arweave.py
+++ b/bitbootpy/core/dhtnetworks/arweave.py
@@ -7,4 +7,4 @@ nodes and an appropriate backend themselves.
 
 from ..dht_network import DHTNetwork, DHT_NETWORK_REGISTRY
 
-DHT_NETWORK_REGISTRY.add(DHTNetwork("arweave"))
+DHT_NETWORK_REGISTRY.add(DHTNetwork("arweave", backend="arweave"))

--- a/bitbootpy/core/dhtnetworks/btc.py
+++ b/bitbootpy/core/dhtnetworks/btc.py
@@ -6,4 +6,4 @@ that projects can supply their own bootstrap list at runtime.
 
 from ..dht_network import DHTNetwork, DHT_NETWORK_REGISTRY
 
-DHT_NETWORK_REGISTRY.add(DHTNetwork("btc"))
+DHT_NETWORK_REGISTRY.add(DHTNetwork("btc", backend="bitcoin"))

--- a/bitbootpy/examples/arweave_store.py
+++ b/bitbootpy/examples/arweave_store.py
@@ -1,0 +1,20 @@
+"""Example using the Arweave backend for simple key/value storage.
+
+Requires ``BITBOOTPY_ARWEAVE_WALLET`` and optionally
+``BITBOOTPY_ARWEAVE_GATEWAY`` environment variables.
+"""
+
+import asyncio
+
+from bitbootpy.core.backends.arweave_backend import ArweaveBackend
+
+
+async def main() -> None:
+    backend = ArweaveBackend()
+    await backend.set(b"hello", b"world")
+    print(await backend.get(b"hello"))
+    backend.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bitbootpy/examples/bitcoin_store.py
+++ b/bitbootpy/examples/bitcoin_store.py
@@ -1,0 +1,20 @@
+"""Example using the Bitcoin backend for simple key/value storage.
+
+Requires ``BITBOOTPY_BTC_KEY`` and ``BITBOOTPY_BTC_RPC_URL`` environment
+variables.
+"""
+
+import asyncio
+
+from bitbootpy.core.backends.bitcoin_backend import BitcoinBackend
+
+
+async def main() -> None:
+    backend = BitcoinBackend()
+    await backend.set(b"hello", b"world")
+    print(await backend.get(b"hello"))
+    backend.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bitbootpy/examples/ethereum_store.py
+++ b/bitbootpy/examples/ethereum_store.py
@@ -1,0 +1,20 @@
+"""Example using the Ethereum backend for simple key/value storage.
+
+Requires ``BITBOOTPY_ETH_KEY``, ``BITBOOTPY_ETH_RPC`` and
+``BITBOOTPY_ETH_CONTRACT`` environment variables.
+"""
+
+import asyncio
+
+from bitbootpy.core.backends.ethereum_backend import EthereumBackend
+
+
+async def main() -> None:
+    backend = EthereumBackend()
+    await backend.set(b"hello", b"world")
+    print(await backend.get(b"hello"))
+    backend.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bitbootpy/examples/solana_store.py
+++ b/bitbootpy/examples/solana_store.py
@@ -1,17 +1,19 @@
-"""Example using the Solana backend for simple key/value storage."""
+"""Example using the Solana backend for simple key/value storage.
+
+Requires ``BITBOOTPY_SOLANA_KEYPAIR`` and optionally
+``BITBOOTPY_SOLANA_RPC`` environment variables.
+"""
 
 import asyncio
 
-from bitbootpy.core.dht_manager import DHTManager
-from bitbootpy.core.dht_network import DHT_NETWORK_REGISTRY, DHTConfig
+from bitbootpy.core.backends.solana_backend import SolanaBackend
 
 
 async def main() -> None:
-    net = DHT_NETWORK_REGISTRY.get("solana")
-    manager = await DHTManager.create(config=DHTConfig(network=net))
-    await manager.set(b"hello", b"world")
-    print(await manager.get(b"hello"))
-    manager.stop()
+    backend = SolanaBackend()
+    await backend.set(b"hello", b"world")
+    print(await backend.get(b"hello"))
+    backend.stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add Arweave blockchain backend and register it
- provide example scripts for Bitcoin, Ethereum, Solana, and Arweave backends
- document required env vars, dependencies, and fees for blockchain backends

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaac9353f4832283d11d9210e574d5