### PR TITLE
Introduce NetworkName enum for canonical networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ when imported. The registry is populated automatically during startup, but you
 can add your own networks by creating a similar module and ensuring it is
 imported.
 
+All networks use canonical names enumerated in
+``bitbootpy.core.network_names.NetworkName`` (e.g. ``NetworkName.BITCOIN``).
+The enum inherits from :class:`str`, so code may use either the enum value or
+the underlying string interchangeably.
+
 For local testing the package also provides a ``local`` network that has no
 bootstrap hosts. Tests and examples can use this lightweight network without
 reaching out to public DHT nodes.

--- a/bitbootpy/core/backends/arweave_backend.py
+++ b/bitbootpy/core/backends/arweave_backend.py
@@ -10,6 +10,7 @@ import requests
 from arweave import Transaction
 
 from ..wallets import get_arweave_wallet
+from ..network_names import NetworkName
 from .base import BaseDHTBackend
 from . import register_backend_with_network
 
@@ -97,4 +98,4 @@ class ArweaveBackend(BaseDHTBackend):
 
 
 # Register backend and associated network
-register_backend_with_network("arweave", ArweaveBackend)
+register_backend_with_network(NetworkName.ARWEAVE, ArweaveBackend)

--- a/bitbootpy/core/backends/bitcoin_backend.py
+++ b/bitbootpy/core/backends/bitcoin_backend.py
@@ -19,7 +19,8 @@ from typing import Any, Iterable, Tuple
 
 from bitcoin.rpc import RawProxy
 
-from ..wallets import get_btc_key, get_btc_rpc_url
+from ..wallets import get_bitcoin_key, get_bitcoin_rpc_url
+from ..network_names import NetworkName
 from .base import BaseDHTBackend
 from . import register_backend_with_network
 
@@ -30,8 +31,8 @@ class BitcoinBackend(BaseDHTBackend):
     PREFIX = b"BitBootPy:"
 
     def __init__(self, rpc_url: str | None = None) -> None:
-        self.key = get_btc_key()
-        self.rpc_url = rpc_url or get_btc_rpc_url()
+        self.key = get_bitcoin_key()
+        self.rpc_url = rpc_url or get_bitcoin_rpc_url()
         self.proxy = RawProxy(service_url=self.rpc_url)
         self._host: Tuple[str, int] = ("0.0.0.0", 0)
         self._nodes: list[Tuple[str, int]] = []
@@ -89,7 +90,7 @@ class BitcoinBackend(BaseDHTBackend):
         """Encode ``key`` and ``value`` in an ``OP_RETURN`` output.
 
         The transaction is funded by the connected node and signed locally with
-        the private key supplied by :func:`get_btc_key`.
+        the private key supplied by :func:`get_bitcoin_key`.
         """
 
         if isinstance(value, bytes):
@@ -120,5 +121,5 @@ class BitcoinBackend(BaseDHTBackend):
 
 
 # Register backend and associated network
-register_backend_with_network("bitcoin", BitcoinBackend, network_name="btc")
+register_backend_with_network(NetworkName.BITCOIN, BitcoinBackend, network_name=NetworkName.BITCOIN)
 

--- a/bitbootpy/core/backends/ethereum_backend.py
+++ b/bitbootpy/core/backends/ethereum_backend.py
@@ -11,7 +11,8 @@ try:  # discovery v5 is optional
 except Exception:  # pragma: no cover - optional
     DiscoveryService = None  # type: ignore
 
-from ..wallets import get_eth_key
+from ..wallets import get_ethereum_key
+from ..network_names import NetworkName
 from .base import BaseDHTBackend
 from . import register_backend_with_network
 
@@ -51,14 +52,16 @@ class EthereumBackend(BaseDHTBackend):
     def __init__(
         self, rpc_url: str | None = None, contract_address: str | None = None
     ) -> None:
-        self.key = get_eth_key()
-        self.rpc_url = rpc_url or os.getenv("BITBOOTPY_ETH_RPC")
+        self.key = get_ethereum_key()
+        self.rpc_url = rpc_url or os.getenv("BITBOOTPY_ETHEREUM_RPC")
         if not self.rpc_url:
-            raise RuntimeError("BITBOOTPY_ETH_RPC environment variable is not set")
+            raise RuntimeError("BITBOOTPY_ETHEREUM_RPC environment variable is not set")
         self.w3 = Web3(Web3.HTTPProvider(self.rpc_url))
-        address = contract_address or os.getenv("BITBOOTPY_ETH_CONTRACT")
+        address = contract_address or os.getenv("BITBOOTPY_ETHEREUM_CONTRACT")
         if not address:
-            raise RuntimeError("BITBOOTPY_ETH_CONTRACT environment variable is not set")
+            raise RuntimeError(
+                "BITBOOTPY_ETHEREUM_CONTRACT environment variable is not set"
+            )
         self.contract = self.w3.eth.contract(
             address=Web3.to_checksum_address(address), abi=self.ABI
         )
@@ -136,4 +139,4 @@ class EthereumBackend(BaseDHTBackend):
 
 
 # Register backend and associated network
-register_backend_with_network("ethereum", EthereumBackend, network_name="eth")
+register_backend_with_network(NetworkName.ETHEREUM, EthereumBackend, network_name=NetworkName.ETHEREUM)

--- a/bitbootpy/core/backends/ethereum_discv5.py
+++ b/bitbootpy/core/backends/ethereum_discv5.py
@@ -10,7 +10,7 @@ protocol.
 
 from typing import Any, Iterable, Tuple
 
-from ..wallets import get_eth_key
+from ..wallets import get_ethereum_key
 from .base import BaseDHTBackend
 
 
@@ -20,7 +20,7 @@ class EthereumDiscv5Backend(BaseDHTBackend):
     def __init__(self) -> None:
         # Load the private key from the environment.  Real implementations would
         # use this key to identify the node on the Ethereum network.
-        self.key = get_eth_key()
+        self.key = get_ethereum_key()
 
     async def listen(self, port: int) -> None:  # pragma: no cover - illustrative
         raise NotImplementedError("Ethereum Discovery v5 backend not implemented")

--- a/bitbootpy/core/backends/kademlia.py
+++ b/bitbootpy/core/backends/kademlia.py
@@ -6,6 +6,7 @@ from typing import Any, Iterable, Tuple
 from kademlia.network import Server
 
 from ..dht_network import KnownHost
+from ..network_names import NetworkName
 from .base import BaseDHTBackend
 from . import register_backend_with_network
 
@@ -43,7 +44,7 @@ class KademliaBackend(BaseDHTBackend):
 register_backend_with_network(
     "kademlia",
     KademliaBackend,
-    network_name="bit_torrent",
+    network_name=NetworkName.BIT_TORRENT,
     bootstrap_hosts=[
         KnownHost("dht.transmissionbt.com", 6881),
         KnownHost("dht.u-phoria.org", 6881),
@@ -58,4 +59,4 @@ register_backend_with_network(
     ],
 )
 
-register_backend_with_network("kademlia", KademliaBackend, network_name="local")
+register_backend_with_network("kademlia", KademliaBackend, network_name=NetworkName.LOCAL)

--- a/bitbootpy/core/backends/solana_backend.py
+++ b/bitbootpy/core/backends/solana_backend.py
@@ -19,6 +19,7 @@ from solders.pubkey import Pubkey
 from solders import system_program as sp
 
 from ..wallets import get_solana_keypair
+from ..network_names import NetworkName
 from .base import BaseDHTBackend
 from . import register_backend_with_network
 
@@ -117,4 +118,4 @@ class SolanaBackend(BaseDHTBackend):
 
 
 # Register backend and associated network
-register_backend_with_network("solana", SolanaBackend)
+register_backend_with_network(NetworkName.SOLANA, SolanaBackend)

--- a/bitbootpy/core/dht_manager.py
+++ b/bitbootpy/core/dht_manager.py
@@ -11,6 +11,7 @@ from .dht_network import (
     DHTNetwork,
     DHT_NETWORK_REGISTRY,
 )
+from .network_names import NetworkName
 from .backends import BACKEND_REGISTRY, BaseDHTBackend
 
 
@@ -100,14 +101,14 @@ class DHTManager:
 
     async def switch_network(
         self,
-        network: Union[str, DHTNetwork],
+        network: Union[str, NetworkName, DHTNetwork],
         bootstrap_nodes: Optional[List[KnownHost]] = None,
     ) -> None:
         """Switch the underlying DHT network and re-bootstrap the server."""
 
         self.stop()
-        if isinstance(network, str):
-            net = DHT_NETWORK_REGISTRY.get(network)
+        if isinstance(network, (str, NetworkName)):
+            net = DHT_NETWORK_REGISTRY.get(str(network))
             if net is None:
                 raise ValueError(f"Unknown DHT network: {network}")
         else:
@@ -129,10 +130,10 @@ class MultiDHTManager:
         self._managers: Dict[str, DHTManager] = {}
 
     def add_network(
-        self, network: Union[str, DHTNetwork], bootstrap_nodes: Optional[List[KnownHost]] = None
+        self, network: Union[str, NetworkName, DHTNetwork], bootstrap_nodes: Optional[List[KnownHost]] = None
     ) -> DHTManager:
-        if isinstance(network, str):
-            net = DHT_NETWORK_REGISTRY.get(network)
+        if isinstance(network, (str, NetworkName)):
+            net = DHT_NETWORK_REGISTRY.get(str(network))
             if net is None:
                 raise ValueError(f"Unknown DHT network: {network}")
         else:
@@ -145,10 +146,10 @@ class MultiDHTManager:
         return manager
 
     async def add_network_async(
-        self, network: Union[str, DHTNetwork], bootstrap_nodes: Optional[List[KnownHost]] = None
+        self, network: Union[str, NetworkName, DHTNetwork], bootstrap_nodes: Optional[List[KnownHost]] = None
     ) -> DHTManager:
-        if isinstance(network, str):
-            net = DHT_NETWORK_REGISTRY.get(network)
+        if isinstance(network, (str, NetworkName)):
+            net = DHT_NETWORK_REGISTRY.get(str(network))
             if net is None:
                 raise ValueError(f"Unknown DHT network: {network}")
         else:

--- a/bitbootpy/core/network.py
+++ b/bitbootpy/core/network.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 from .dht_network import DHTNetwork, DHT_NETWORK_REGISTRY
+from .network_names import NetworkName
 
 
 @dataclass
@@ -42,7 +43,7 @@ class NetworkRegistry:
     def create(
         self, name: str, dht_networks: Optional[List[DHTNetwork]] = None
     ) -> Network:
-        dht_networks = dht_networks or [DHT_NETWORK_REGISTRY.get("bit_torrent")]
+        dht_networks = dht_networks or [DHT_NETWORK_REGISTRY.get(NetworkName.BIT_TORRENT)]
         network = Network(name, dht_networks)
         return self.add(network)
 

--- a/bitbootpy/core/network_names.py
+++ b/bitbootpy/core/network_names.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Enumerations of built-in network identifiers.
+
+The project historically referenced networks by string name.  This module
+introduces :class:`NetworkName` which enumerates the canonical names used across
+BitBootPy.  Using an ``Enum`` provides a fully specified way to select networks
+while still behaving like ``str`` for backward compatibility.
+"""
+
+from enum import Enum
+
+
+class NetworkName(str, Enum):
+    """Canonical identifiers for built-in networks."""
+
+    BIT_TORRENT = "bit_torrent"
+    LOCAL = "local"
+    BITCOIN = "bitcoin"
+    ETHEREUM = "ethereum"
+    SOLANA = "solana"
+    ARWEAVE = "arweave"
+

--- a/bitbootpy/core/wallets.py
+++ b/bitbootpy/core/wallets.py
@@ -13,25 +13,25 @@ from arweave import Wallet
 
 def _require_env(var: str) -> str:
     value = os.getenv(var)
-    if not value:
-        raise RuntimeError(f"{var} environment variable is not set")
-    return value
+    if value:
+        return value
+    raise RuntimeError(f"{var} environment variable is not set")
 
 
-def get_btc_key() -> BTCKey:
-    """Return a Bitcoin ``Key`` from ``BITBOOTPY_BTC_KEY``."""
-    key_str = _require_env("BITBOOTPY_BTC_KEY")
+def get_bitcoin_key() -> BTCKey:
+    """Return a Bitcoin ``Key`` from ``BITBOOTPY_BITCOIN_KEY``."""
+    key_str = _require_env("BITBOOTPY_BITCOIN_KEY")
     return BTCKey(key_str)
 
 
-def get_btc_rpc_url() -> str:
-    """Return the Bitcoin RPC URL from ``BITBOOTPY_BTC_RPC_URL``."""
-    return _require_env("BITBOOTPY_BTC_RPC_URL")
+def get_bitcoin_rpc_url() -> str:
+    """Return the Bitcoin RPC URL from ``BITBOOTPY_BITCOIN_RPC_URL``."""
+    return _require_env("BITBOOTPY_BITCOIN_RPC_URL")
 
 
-def get_eth_key() -> eth_keys.PrivateKey:
-    """Return an Ethereum ``PrivateKey`` from ``BITBOOTPY_ETH_KEY``."""
-    key_str = _require_env("BITBOOTPY_ETH_KEY")
+def get_ethereum_key() -> eth_keys.PrivateKey:
+    """Return an Ethereum ``PrivateKey`` from ``BITBOOTPY_ETHEREUM_KEY``."""
+    key_str = _require_env("BITBOOTPY_ETHEREUM_KEY")
     if key_str.startswith("0x") or key_str.startswith("0X"):
         key_str = key_str[2:]
     key_bytes = bytes.fromhex(key_str)

--- a/bitbootpy/examples/solana_store.py
+++ b/bitbootpy/examples/solana_store.py
@@ -4,10 +4,11 @@ import asyncio
 
 from bitbootpy.core.dht_manager import DHTManager
 from bitbootpy.core.dht_network import DHT_NETWORK_REGISTRY, DHTConfig
+from bitbootpy.core.network_names import NetworkName
 
 
 async def main() -> None:
-    net = DHT_NETWORK_REGISTRY.get("solana")
+    net = DHT_NETWORK_REGISTRY.get(NetworkName.SOLANA)
     manager = await DHTManager.create(config=DHTConfig(network=net))
     await manager.set(b"hello", b"world")
     print(await manager.get(b"hello"))

--- a/tests/test_known_hosts.py
+++ b/tests/test_known_hosts.py
@@ -1,4 +1,3 @@
-import pytest
 from bitbootpy.core.dht_network import (
     add_network,
     remove_network,
@@ -7,6 +6,8 @@ from bitbootpy.core.dht_network import (
     DHT_NETWORK_REGISTRY,
     KnownHost,
 )
+from bitbootpy.core.backends import BACKEND_REGISTRY
+from bitbootpy.core.network_names import NetworkName
 
 
 def test_dynamic_known_hosts():
@@ -18,3 +19,9 @@ def test_dynamic_known_hosts():
     assert host not in DHT_NETWORK_REGISTRY.get(network.name).bootstrap_hosts
     remove_network(network.name)
     assert DHT_NETWORK_REGISTRY.get(network.name) is None
+
+
+def test_builtin_networks_registered():
+    # built-in networks register with canonical names
+    assert DHT_NETWORK_REGISTRY.get(NetworkName.BITCOIN) is not None
+    assert NetworkName.BITCOIN in BACKEND_REGISTRY

--- a/tests/test_peer_discovery.py
+++ b/tests/test_peer_discovery.py
@@ -2,6 +2,8 @@ import asyncio
 import functools
 import pytest
 
+from bitbootpy.core.network_names import NetworkName
+
 # Compatibility shim for libraries expecting ``asyncio.coroutine``
 
 def _compat_coroutine(func):
@@ -53,7 +55,7 @@ class DummyBackend:
 @pytest.mark.asyncio
 async def test_peer_discovery_dummy_network():
     dummy = DummyBackend()
-    local_net = DHT_NETWORK_REGISTRY.get("local")
+    local_net = DHT_NETWORK_REGISTRY.get(NetworkName.LOCAL)
     test_network = NETWORK_REGISTRY.create("test_topic", [local_net])
     config_a = BitBootConfig(dht=DHTConfig(network=local_net))
     config_b = BitBootConfig(dht=DHTConfig(network=local_net))

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -10,9 +10,9 @@ from arweave import Wallet
 from Crypto.PublicKey import RSA
 
 from bitbootpy.core.wallets import (
-    get_btc_key,
-    get_btc_rpc_url,
-    get_eth_key,
+    get_bitcoin_key,
+    get_bitcoin_rpc_url,
+    get_ethereum_key,
     get_solana_keypair,
     get_arweave_wallet,
 )
@@ -21,42 +21,42 @@ from bitbootpy.core.backends.solana_backend import SolanaBackend
 
 
 def test_missing_env(monkeypatch):
-    monkeypatch.delenv("BITBOOTPY_BTC_KEY", raising=False)
-    monkeypatch.delenv("BITBOOTPY_BTC_RPC_URL", raising=False)
-    monkeypatch.delenv("BITBOOTPY_ETH_KEY", raising=False)
+    monkeypatch.delenv("BITBOOTPY_BITCOIN_KEY", raising=False)
+    monkeypatch.delenv("BITBOOTPY_BITCOIN_RPC_URL", raising=False)
+    monkeypatch.delenv("BITBOOTPY_ETHEREUM_KEY", raising=False)
     monkeypatch.delenv("BITBOOTPY_SOLANA_KEYPAIR", raising=False)
     monkeypatch.delenv("BITBOOTPY_ARWEAVE_WALLET", raising=False)
 
     with pytest.raises(RuntimeError):
-        get_btc_key()
+        get_bitcoin_key()
     with pytest.raises(RuntimeError):
-        get_btc_rpc_url()
+        get_bitcoin_rpc_url()
     with pytest.raises(RuntimeError):
-        get_eth_key()
+        get_ethereum_key()
     with pytest.raises(RuntimeError):
         get_solana_keypair()
     with pytest.raises(RuntimeError):
         get_arweave_wallet()
 
 
-def test_get_btc_key(monkeypatch):
+def test_get_bitcoin_key(monkeypatch):
     k = BTCKey()
-    monkeypatch.setenv("BITBOOTPY_BTC_KEY", k.wif())
-    loaded = get_btc_key()
+    monkeypatch.setenv("BITBOOTPY_BITCOIN_KEY", k.wif())
+    loaded = get_bitcoin_key()
     assert isinstance(loaded, BTCKey)
     assert loaded.wif() == k.wif()
 
 
-def test_get_btc_rpc_url(monkeypatch):
+def test_get_bitcoin_rpc_url(monkeypatch):
     url = "http://localhost:8332"
-    monkeypatch.setenv("BITBOOTPY_BTC_RPC_URL", url)
-    assert get_btc_rpc_url() == url
+    monkeypatch.setenv("BITBOOTPY_BITCOIN_RPC_URL", url)
+    assert get_bitcoin_rpc_url() == url
 
 
-def test_get_eth_key(monkeypatch):
+def test_get_ethereum_key(monkeypatch):
     pk = eth_keys.PrivateKey(os.urandom(32))
-    monkeypatch.setenv("BITBOOTPY_ETH_KEY", pk.to_hex())
-    loaded = get_eth_key()
+    monkeypatch.setenv("BITBOOTPY_ETHEREUM_KEY", pk.to_hex())
+    loaded = get_ethereum_key()
     assert isinstance(loaded, eth_keys.PrivateKey)
     assert loaded == pk
 
@@ -94,7 +94,7 @@ def test_get_arweave_wallet(monkeypatch):
 
 def test_ethereum_backend_uses_helper(monkeypatch):
     pk = eth_keys.PrivateKey(os.urandom(32))
-    monkeypatch.setenv("BITBOOTPY_ETH_KEY", pk.to_hex())
+    monkeypatch.setenv("BITBOOTPY_ETHEREUM_KEY", pk.to_hex())
     backend = EthereumDiscv5Backend()
     assert backend.key == pk
 


### PR DESCRIPTION
## Summary
- define `NetworkName` enum listing canonical DHT and blockchain networks
- allow backend registration and DHT utilities to accept enums instead of raw strings
- document enum-based network selection and update examples/tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab3f4581508322b587fed0259fe0d5