### PR TITLE
Simplify Bitcoin backend registration

### DIFF
--- a/bitbootpy/core/backends/bitcoin_backend.py
+++ b/bitbootpy/core/backends/bitcoin_backend.py
@@ -21,6 +21,7 @@ from bitcoin.rpc import RawProxy
 
 from ..wallets import get_bitcoin_key, get_bitcoin_rpc_url
 from ..network_names import NetworkName
+from ..dht_network import KnownHost
 from .base import BaseDHTBackend
 from . import register_backend_with_network
 
@@ -121,5 +122,15 @@ class BitcoinBackend(BaseDHTBackend):
 
 
 # Register backend and associated network
-register_backend_with_network(NetworkName.BITCOIN, BitcoinBackend, network_name=NetworkName.BITCOIN)
+bootstrap_hosts = [
+    KnownHost("seed.bitcoin.sipa.be", 8333),
+    KnownHost("dnsseed.bluematt.me", 8333),
+    KnownHost("seed.bitcoinstats.com", 8333),
+    KnownHost("seed.bitcoin.jonasschnelli.ch", 8333),
+]
+register_backend_with_network(
+    NetworkName.BITCOIN,
+    BitcoinBackend,
+    bootstrap_hosts=bootstrap_hosts,
+)
 


### PR DESCRIPTION
## Summary
- Register Bitcoin backend using default network name and bootstrap hosts
- Add KnownHost bootstrap list for Bitcoin network

## Testing
- `pytest tests/test_bitcoin_backend.py -q` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab511fe9a48322bbef91b3944fdb2f