### PR TITLE
Remove redundant network_name in Ethereum backend registration

### DIFF
--- a/bitbootpy/core/backends/ethereum_backend.py
+++ b/bitbootpy/core/backends/ethereum_backend.py
@@ -139,4 +139,4 @@ class EthereumBackend(BaseDHTBackend):
 
 
 # Register backend and associated network
-register_backend_with_network(NetworkName.ETHEREUM, EthereumBackend, network_name=NetworkName.ETHEREUM)
+register_backend_with_network(NetworkName.ETHEREUM, EthereumBackend)


### PR DESCRIPTION
## Summary
- simplify Ethereum backend registration by letting helper infer network name

## Testing
- `pytest tests/test_peer_discovery.py tests/test_wallets.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5138597083228aa7a37057d5573b